### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,12 @@ repos:
       args: [--line-length=88]
       language_version: python3.11
 
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in .pre-commit-config.yaml
+  rev: v2.4.1
+  hooks:
+  - id: codespell
+
 ci:
   skip: [hadolint-docker]
+

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker run -it --rm --entrypoint=/usr/bin/python3 bids/ip-freely:testing /test_p
 -   `-g` / `--graph`:
 
     This option produces a JSON file encoding the full relational structure
-    betwen datafiles and metadata files in the dataset:
+    between datafiles and metadata files in the dataset:
 
     -   For each *data file*,
         the output of this option contains a *dictionary*

--- a/ipfreely/__init__.py
+++ b/ipfreely/__init__.py
@@ -2,7 +2,7 @@ import sys
 
 # Codebase uses subscripted type hints
 if sys.version_info < (3, 9):
-    sys.stderr.write("Requies Python version 3.9 or later\n")
+    sys.stderr.write("Requires Python version 3.9 or later\n")
     sys.exit(1)
 
 


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.